### PR TITLE
Limit dashboard transactions

### DIFF
--- a/api/transactions/urls.py
+++ b/api/transactions/urls.py
@@ -1,13 +1,13 @@
 from django.urls import path
 from .views import (
-    TransactionView,
+    TransactionsView,
     TransactionDetailView,
     OfxTransactionUpload,
 )
 
 
 urlpatterns = [
-    path('', TransactionView.as_view(), name='index'),
+    path('', TransactionsView.as_view(), name='index'),
     path('upload/', OfxTransactionUpload.as_view(), name='upload'),
     path('<str:transaction_id>/', TransactionDetailView.as_view()),
 ]

--- a/api/transactions/views.py
+++ b/api/transactions/views.py
@@ -18,13 +18,7 @@ from rest_framework import generics
 def index(request):
     return HttpResponse("Counting them bones")
 
-
-def colors(request):
-    colors = Colors.objects.all()
-    return JsonResponse(list(colors.values()), safe=False)
-
-
-class TransactionView(APIView):
+class TransactionsView(APIView):
     # add permission to check if user is authenticated
     authentication_classes = [BasicAuthentication, TokenAuthentication]
     permission_classes = [permissions.IsAuthenticated]
@@ -33,7 +27,15 @@ class TransactionView(APIView):
         """
         List all the transaction items for a given requested user
         """
-        transactions = Transaction.objects.filter(user_id=request.user.id)
+        first = self.request.query_params['limit']
+        if (first is None):
+            first = 100
+        elif first == '-1':
+            first = 100
+        else:
+            first = int(first)
+
+        transactions = Transaction.objects.filter(user_id=request.user.id)[:first]
         serializer = TransactionSerializer(transactions, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/web/src/features/Transactions/index.tsx
+++ b/web/src/features/Transactions/index.tsx
@@ -6,11 +6,15 @@ import { getTransactions } from 'state/transactions';
 import Transaction from 'components/Transactions/Transaction';
 import { ListItem } from 'components/ui';
 
-const TransactionsList = React.memo(() => {
+interface TransactionsListProps {
+  limit?: number;
+}
+
+const TransactionsList = React.memo<TransactionsListProps>(({ limit = -1 }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(getTransactions());
+    dispatch(getTransactions(limit));
   }, [dispatch]);
 
   const transactions = useSelector((state) => state.transactions).transactions;

--- a/web/src/state/transactions/reducer.ts
+++ b/web/src/state/transactions/reducer.ts
@@ -8,7 +8,7 @@ import { getResponseTransactions } from './utils';
 
 export const getTransactions = createAsyncThunk(
   'transactions/getTransactions',
-  async () => requestGet('transactions'),
+  async (limit?: number) => requestGet(`transactions`, { limit: limit ?? '' }),
 );
 
 export const uploadTransactions = createAsyncThunk(

--- a/web/src/views/Dashboard/index.tsx
+++ b/web/src/views/Dashboard/index.tsx
@@ -1,21 +1,34 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { Block, H1 } from 'components/ui';
+import { Block, Button, H1 } from 'components/ui';
 
 import Layout from 'features/Layout';
 
 import TransactionsList from 'features/Transactions';
 
-const DashboardView: React.FunctionComponent = () => (
-  <Layout>
-    <div className="layout-view">
-      <H1 heading={2}>Recent transactions</H1>
+const DashboardView: React.FunctionComponent = () => {
+  const navigate = useNavigate();
 
-      <Block offset offsetSize="lg">
-        <TransactionsList />
-      </Block>
-    </div>
-  </Layout>
-);
+  const handleSeeAllClick = useCallback(() => {
+    navigate('/transactions');
+  }, [navigate]);
+
+  return (
+    <Layout>
+      <div className="layout-view">
+        <H1 heading={2}>Recent transactions</H1>
+  
+        <Block offset offsetSize="lg">
+          <TransactionsList limit={5} />
+  
+          <Block offset offsetSize="lg">
+            <Button onClick={handleSeeAllClick}>See all transactions</Button>
+          </Block>
+        </Block>
+      </div>
+    </Layout>
+  );
+};
 
 export default DashboardView;

--- a/web/src/views/Transactions/index.tsx
+++ b/web/src/views/Transactions/index.tsx
@@ -1,30 +1,18 @@
-import React, { useEffect } from 'react';
-
-import { useDispatch, useSelector } from 'state';
-import { getTransactions } from 'state/transactions';
+import React from 'react';
 
 import { Block, H1 } from 'components/ui';
 
 import Layout from 'features/Layout';
+import TransactionsList from 'features/Transactions';
 
 const TransactionsView: React.FunctionComponent = () => {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(getTransactions());
-  }, [dispatch]);
-
-  const transactions = useSelector((state) => state.transactions).transactions;
-
   return (
     <Layout>
       <div className="layout-view">
-        <H1>Transactions</H1>
+        <H1 heading={2}>Transactions</H1>
 
-        <Block offset>
-          <ul>
-            {transactions.map((t) => (<li key={t.id}>${t.amount.toFixed(2)} - {t.description}</li>))}
-          </ul>
+        <Block offset offsetSize="lg">
+          <TransactionsList />
         </Block>
       </div>
     </Layout>


### PR DESCRIPTION
Limit transactions on the dashboard to make it more clear that it's meant to be a summary, whereas the /transactions page lists everything.